### PR TITLE
NV-4418 Make the GitLab pipeline self-contained

### DIFF
--- a/.github/workflows/nightvision.yml
+++ b/.github/workflows/nightvision.yml
@@ -15,6 +15,22 @@ on:
   push:
     branches:
       - main
+    # Do not run the DAST scan when a push touches only files that cannot affect the
+    # scanned app or the scan itself: docs, other-platform CI glue, and the manual-only
+    # sibling notification workflows. App source, specs, Dockerfile/compose, build files,
+    # scan config, and this workflow still trigger a scan. (NV-4462.)
+    paths-ignore:
+      - '**/*.md'
+      - '.gitignore'
+      - '.gitlab-ci.yml'
+      - 'convert_sarif_to_gitlab.py'
+      - 'azure-pipelines.yml'
+      - 'sarif_to_azure_devops.py'
+      - 'bitbucket-pipelines.yml'
+      - 'Jenkinsfile'
+      - '.github/workflows/nightvision-email.yml'
+      - '.github/workflows/nightvision-slack.yml'
+      - '.github/workflows/nightvision-teams.yml'
   workflow_dispatch:
 
 env:
@@ -36,15 +52,29 @@ jobs:
             wget -c https://downloads.nightvision.net/binaries/latest/nightvision_latest_linux_amd64.tar.gz -O - | tar -xz; sudo mv nightvision /usr/local/bin/
                     python -m pip install semgrep --user
 
+      # Extract the spec to a local file and assert it is non-empty. The '|| true' mask
+      # and the backup-spec fallback are dropped so a real API Discovery regression turns
+      # the run red instead of silently scanning with a stale spec. (NV-4462.)
       - name: (3) Extract API documentation from code
         run: |
-          nightvision swagger extract ./ -t ${NIGHTVISION_TARGET} --lang spring || true
-          if [ ! -e openapi-spec.yml ]; then
-              cp backup-openapi-spec.yml openapi-spec.yml
-          fi
+          nightvision swagger extract ./ --lang spring -o openapi-spec.yml --no-upload
+          test -s openapi-spec.yml
 
-      - name: (4) Start the app
-        run: docker compose up -d; sleep 10
+      # Spring Boot + Postgres cold start (after the Gradle image build) routinely
+      # exceeds a fixed sleep, and compose's depends_on waits only for container start,
+      # not for the app to accept connections. Poll until it responds (any HTTP status
+      # means it is listening) instead of sleeping a flat 10s; on timeout, dump logs and
+      # fail loudly rather than letting the scan flake later. --retry-max-time caps the
+      # whole loop (~150s) so a listening-but-hung port fails fast instead of burning
+      # --max-time on every one of --retry attempts. (NV-4462.)
+      - name: (4) Start the app and wait until it is ready
+        run: |
+          docker compose up -d
+          if ! curl -sk --retry 60 --retry-delay 2 --retry-max-time 150 --retry-all-errors --max-time 5 -o /dev/null https://127.0.0.1:9000/; then
+            echo "App did not become ready in time; recent compose logs:"
+            docker compose logs --no-color --tail 200
+            exit 1
+          fi
 
       - name: (5) Scan the API
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ bin/
 .settings/
 .env
 .DS_Store
+__pycache__

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -66,8 +66,18 @@ dast_scan:
 
 convert_sarif_to_gitlab:
   stage: convert_sarif_to_gitlab
-  image: python:3.9 
+  image: python:3.9
   script:
+    # Fetch the converter from its single canonical location so this pipeline is
+    # self-contained: a repo that copy-pastes only this YAML (without bundling the
+    # Python script) still produces the report on this final stage. (NV-4418.)
+    # -f makes curl fail loudly on an HTTP error so a missing/moved converter does not
+    # silently produce an empty report.
+    # POC limitation: this pins to the mutable 'main' branch (no tag/SHA or checksum),
+    # so a converter change is picked up automatically. Pin to a tag/commit SHA before
+    # promoting this pattern past the POC.
+    # Phase 1 (NV-4412) replaces this fetch + script with `nightvision export gitlab`.
+    - curl -sSfL https://raw.githubusercontent.com/nvsecurity/nv-public-reference/main/sarif/convert_sarif_to_gitlab.py -o convert_sarif_to_gitlab.py
     - python3 convert_sarif_to_gitlab.py
   artifacts:
     reports:

--- a/convert_sarif_to_gitlab.py
+++ b/convert_sarif_to_gitlab.py
@@ -1,3 +1,7 @@
+# SUPERSEDED: the GitLab pipeline (.gitlab-ci.yml) now fetches the single canonical
+# converter from nvsecurity/nv-public-reference at runtime, so this in-repo copy is no
+# longer used by CI. Kept only to avoid a noisy delete on this POC branch; removal is
+# tracked under NV-4412. Do not edit this copy - change the canonical converter.
 import json
 from datetime import datetime
 


### PR DESCRIPTION
Two related changes to the demo repo's CI. Make the GitLab pipeline self-contained so a copy-pasted YAML produces the report without bundling the converter (NV-4418), and scope and harden the GitHub Actions DAST scan so it runs reliably and only on pushes that can affect it (NV-4462).

## Implementation

- **Self-contained GitLab converter fetch (NV-4418)**: `.gitlab-ci.yml` fetches the canonical `convert_sarif_to_gitlab.py` at runtime with `curl -sSfL`, so a repo holding only the YAML still produces the report; the `main` pin is a documented POC choice.
- **Mark the in-repo converter superseded (NV-4418)**: `convert_sarif_to_gitlab.py` gains a header noting CI no longer uses it, with removal tracked under NV-4412.
- **Scope the GitHub demo scan with `paths-ignore` (NV-4462)**: `nightvision.yml` no longer runs the DAST scan on docs, other-platform CI, or notification-only pushes.
- **Assert spec extraction instead of masking failures (NV-4462)**: extraction now writes a local spec and asserts it is non-empty, dropping the `|| true` mask and backup-spec fallback so an API Discovery regression fails the run.
- **Bounded readiness poll before scanning (NV-4462)**: the fixed `sleep` is replaced by a `curl` poll that waits until the app answers and is time-capped, dumping container logs and failing on timeout.

## Out-of-scope

- **GitLab pipeline extraction and readiness**: the GitLab side keeps its `|| true` mask and a fixed `sleep`; converging both demo pipelines on one extraction and readiness contract is deferred to NV-4412.
- **Converter pinning and cleanup**: pinning the fetch to a tag or commit SHA instead of `main`, and deleting the superseded in-repo converter, are deferred to NV-4412.
