### PR TITLE
NV-4462 Surface the demo scan's error output on failure

### DIFF
--- a/.github/workflows/nightvision.yml
+++ b/.github/workflows/nightvision.yml
@@ -78,7 +78,14 @@ jobs:
 
       - name: (5) Scan the API
         run: |
-          nightvision scan ${NIGHTVISION_TARGET} --auth ${NIGHTVISION_AUTH} > scan-results.txt
+          # stdout is redirected to scan-results.txt (its first line feeds the export
+          # below), which also swallows any scan error. Print the captured output and
+          # fail explicitly so a scan failure is diagnosable instead of opaque. (NV-4462.)
+          if ! nightvision scan ${NIGHTVISION_TARGET} --auth ${NIGHTVISION_AUTH} > scan-results.txt; then
+            echo "nightvision scan failed; captured output:"
+            cat scan-results.txt
+            exit 1
+          fi
           nightvision export sarif -s "$(head -n 1 scan-results.txt)" --swagger-file openapi-spec.yml
 
       - name: (6) Upload SARIF file to GitHub Security Alerts if vulnerabilities are found


### PR DESCRIPTION
The scan step redirects stdout to scan-results.txt (its first line feeds the SARIF export), which also swallows any scan error, so a failed scan ends the step with exit 1 and no diagnostic. Wrap the scan so that on failure it prints the captured output and then fails, making credential/target/connectivity errors visible in the Actions log instead of opaque.